### PR TITLE
Use `sudo -E` when creating the port forward

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -663,7 +663,11 @@ start-ui-port-forward: | $(KUBECTL) ## Start a port from the eda api service to 
 		CLUSTER_EXT_DOMAIN_NAME=$$($(KUBECTL) get engineconfigs.core.eda.nokia.com engine-config -ojsonpath='{.spec.cluster.external.domainName}')	;\
 		CLUSTER_EXT_HTTPS_PORT=$$($(KUBECTL) get engineconfigs.core.eda.nokia.com engine-config -ojsonpath='{.spec.cluster.external.httpsPort}')	;\
 		echo "--> The UI can be accessed using https://$${CLUSTER_EXT_DOMAIN_NAME}:$${CLUSTER_EXT_HTTPS_PORT}"										;\
-		sudo -E $(KUBECTL) port-forward service/eda-api --address 0.0.0.0 $${CLUSTER_EXT_HTTPS_PORT}:443													;\
+                port_forward_cmd="$(KUBECTL) port-forward service/eda-api --address 0.0.0.0 $${CLUSTER_EXT_HTTPS_PORT}:443" ;\
+                if [[ $${CLUSTER_EXT_HTTPS_PORT} -eq 443 ]]; then \
+		port_forward_cmd="sudo -E $${port_forward_cmd}" ;\
+		fi ;\
+		eval $$port_forward_cmd ;\
 	}
 
 


### PR DESCRIPTION
If a user chooses to use port 443 as an HTTPS port for the external cluster accees, the `make start-ui-port-forward` might fail, if a user is not a root user.

```
└──> make start-ui-port-forward
--> Exposing the UI to the host across the kind container boundary
--> The UI can be accessed using https://nfd1.eda.dev:443
Unable to listen on port 443: Listeners failed to create with the following errors: [unable to create listener: Error listen tcp4 0.0.0.0:443: bind: permission denied]
error: unable to listen on any of the requested ports: [{443 9443}]
make: *** [Makefile:661: start-ui-port-forward] Error 1
```

This PR adds `sudo -E` command so that the port forward with a privileged target port is possible.