### PR TITLE
fix: Ensure containerd picks up dynamic registry configuration

### DIFF
--- a/configs/kind.yaml
+++ b/configs/kind.yaml
@@ -7,6 +7,11 @@ networking:
   # change the API server address from loopback to the desired IP
   # via KIND_API_SERVER_ADDRESS make variable
   apiServerAddress: "127.0.0.1"
+# Ensure that edabuilder dev-registry patches are taken into account
+containerdConfigPatches:
+- >-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"
 nodes:
   - role: control-plane
     # https://kind.sigs.k8s.io/docs/user/configuration/#extra-port-mappings


### PR DESCRIPTION
`edabuilder deploy` provisions an in-cluster registry, and helpfully deploys custom host entries for containerd per https://github.com/containerd/containerd/blob/main/docs/hosts.md#simple-default-host-config-for-docker

But the kind configuration for the playground does not configure containerd to load these. See https://kind.sigs.k8s.io/docs/user/local-registry/

This becomes an issue when bundling controllers/workflows inside the app OCI